### PR TITLE
fix(github actions): install deps on the top-level

### DIFF
--- a/packages/cpg-github-actions/template/.github/workflows/CI.yml
+++ b/packages/cpg-github-actions/template/.github/workflows/CI.yml
@@ -30,7 +30,6 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/$PKG_MANAGER_LOCK') }}
 
       - name: Install dependencies
-        working-directory: $WORKING_DIR
         run: $INSTALL_CMD_WITH_FROZEN_LOCK
 
       - name: Run Tests 🧪
@@ -56,7 +55,6 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/$PKG_MANAGER_LOCK') }}
 
       - name: Install dependencies
-        working-directory: $WORKING_DIR
         run: $INSTALL_CMD_WITH_FROZEN_LOCK
 
       - name: Publish 🚀


### PR DESCRIPTION
Install deps on the top-level cause npm expects a lock file where you run the command.

Fixing: #87 